### PR TITLE
Support custom PyPI index URLs and custom template files

### DIFF
--- a/poet/poet.py
+++ b/poet/poet.py
@@ -12,8 +12,6 @@ from __future__ import print_function
 import argparse
 import codecs
 from collections import OrderedDict
-from contextlib import closing
-from hashlib import sha256
 import json
 import logging
 import os
@@ -24,15 +22,9 @@ import pkg_resources
 import pypi_simple
 
 from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE
-from .util import extract_credentials_from_url, transform_url
+from .util import compute_sha256_sum, extract_credentials_from_url, transform_url
 from .version import __version__
 
-try:
-    # Python 2.x
-    from urllib2 import urlopen
-except ImportError:
-    # Python 3.x
-    from urllib.request import urlopen
 
 # Show warnings and greater by default
 logging.basicConfig(level=int(os.environ.get("POET_DEBUG", 30)))
@@ -122,7 +114,7 @@ def research_package(index_url, name, version=None):
         sha256_sum = digests["sha256"]
     except KeyError:
         logging.debug("Fetching sdist to compute checksum for %s", name)
-        sha256_sum = _compute_sha256_sum(matching_distribution.url)
+        sha256_sum = compute_sha256_sum(matching_distribution.url)
         logging.debug("Done fetching %s", name)
 
     package["checksum"] = sha256_sum
@@ -156,11 +148,6 @@ def _find_exact_version(version, distributions):
             return dist
 
     return None
-
-
-def _compute_sha256_sum(url):
-    with closing(urlopen(url)) as file_:
-        return sha256(file_.read()).hexdigest()
 
 
 def make_graph(index_url, pkg):

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -199,7 +199,7 @@ def formula_for(index_url, package, also=None, template_path=None):
     else:
         raise Exception("Could not find package {} in nodes {}".format(package, nodes.keys()))
 
-    python = "python" if sys.version_info.major == 2 else "python3"
+    python = "python@2" if sys.version_info.major == 2 else "python@3"
 
     template = template_from_file(template_path) if template_path else FORMULA_TEMPLATE
 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -182,7 +182,7 @@ def make_graph(index_url, pkg):
     )
 
 
-def formula_for(index_url, package, also=None, template_path=None):
+def formula_for(index_url, package, also=None, template_path=None, include_python_minor_version=False):
     also = also or []
 
     req = pkg_resources.Requirement.parse(package)
@@ -199,7 +199,9 @@ def formula_for(index_url, package, also=None, template_path=None):
     else:
         raise Exception("Could not find package {} in nodes {}".format(package, nodes.keys()))
 
-    python = "python@2" if sys.version_info.major == 2 else "python@3"
+    python = "python@{}".format(sys.version_info.major)
+    if include_python_minor_version:
+        python += ".{}".format(sys.version_info.minor)
 
     template = template_from_file(template_path) if template_path else FORMULA_TEMPLATE
 
@@ -266,6 +268,10 @@ def main():
     parser.add_argument(
         '--formula-template',
         help='A custom Jinja2 template file to use if generating a forumla')
+    parser.add_argument(
+        '--include-python-minor-version',
+        action="store_true",
+        help='Include the minor version in the dependency on python')
     args = parser.parse_args()
 
     if (args.formula or args.resources) and args.package:
@@ -281,7 +287,15 @@ def main():
         return 1
 
     if args.formula:
-        print(formula_for(args.index_url, args.formula, args.also, args.formula_template))
+        print(
+            formula_for(
+                args.index_url,
+                args.formula,
+                args.also,
+                args.formula_template,
+                args.include_python_minor_version,
+            )
+        )
     elif args.single:
         for i, package in enumerate(args.single):
             data = research_package(args.index_url, package)

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -47,3 +47,8 @@ RESOURCE_TEMPLATE = env.from_string("""\
     {{ resource.checksum_type }} "{{ resource.checksum }}"
   end
 """)
+
+
+def template_from_file(path):
+    with open(path) as file_:
+      return env.from_string(file_.read())

--- a/poet/util.py
+++ b/poet/util.py
@@ -1,9 +1,13 @@
+from contextlib import closing
+from hashlib import sha256
+
 try:
     # Python 2.x
-    from urllib2 import urlparse, urlunparse
+    from urllib2 import urlopen, urlparse, urlunparse
 except ImportError:
     # Python 3.x
     from urllib.parse import urlparse, urlunparse
+    from urllib.request import urlopen
 
 
 _PARSED_URL_INDICES = {
@@ -48,3 +52,8 @@ def transform_url(url, **kwargs):
         url_parts[index] = value
 
     return urlunparse(tuple(url_parts))
+
+
+def compute_sha256_sum(url):
+    with closing(urlopen(url)) as file_:
+        return sha256(file_.read()).hexdigest()

--- a/poet/util.py
+++ b/poet/util.py
@@ -1,3 +1,21 @@
+try:
+    # Python 2.x
+    from urllib2 import urlparse, urlunparse
+except ImportError:
+    # Python 3.x
+    from urllib.parse import urlparse, urlunparse
+
+
+_PARSED_URL_INDICES = {
+    "scheme": 0,
+    "netloc": 1,
+    "path": 2,
+    "params": 3,
+    "query": 4,
+    "fragment": 5,
+}
+
+
 def dash_to_studly(s):
     l = list(s)
     l[0] = l[0].upper()
@@ -10,3 +28,23 @@ def dash_to_studly(s):
     for d in delims:
         out = out.replace(d, "")
     return out
+
+
+def extract_credentials_from_url(url):
+    parsed_url = urlparse(url)
+    url_without_credentials = transform_url(url, netloc=parsed_url.hostname)
+    return url_without_credentials, parsed_url.username, parsed_url.password
+
+
+def transform_url(url, **kwargs):
+    url_parts = list(urlparse(url))
+
+    for key, value in kwargs.items():
+        try:
+            index = _PARSED_URL_INDICES[key]
+        except KeyError:
+            continue
+
+        url_parts[index] = value
+
+    return urlunparse(tuple(url_parts))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['jinja2', 'setuptools'],
+    install_requires=['jinja2', 'pypi-simple', 'setuptools'],
     entry_points={'console_scripts': [
         'poet=poet:main',
         'poet_lint=poet.lint:main',


### PR DESCRIPTION
This adds the following options:
* `--index-url`: URL of a custom package index to use instead of PyPI
* `--formula-template`: path to a custom Jinja template to use when generating formulae
* `--include-python-minor-version`: include the minor version of the Python interpreter in the `depends_on @python` directive