### PR TITLE
Put an upperbound on `pypi-simple` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
     ],
-    install_requires=['jinja2', 'pypi-simple', 'setuptools'],
+    install_requires=['jinja2', 'pypi-simple < 1', 'setuptools'],
     entry_points={'console_scripts': [
         'poet=poet:main',
         'poet_lint=poet.lint:main',


### PR DESCRIPTION
[v1.0.0](https://github.com/jwodder/pypi-simple/releases/tag/v1.0.0) of this library introduced breaking changes that cause errors such as:
```
Traceback (most recent call last):
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/bin/poet", line 33, in <module>
    sys.exit(load_entry_point('homebrew-pypi-poet', 'console_scripts', 'poet')())
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 292, in main
    formula_for(
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 191, in formula_for
    nodes = merge_graphs(make_graph(index_url, p) for p in [package] + also)
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 225, in merge_graphs
    for g in graphs:
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 191, in <genexpr>
    nodes = merge_graphs(make_graph(index_url, p) for p in [package] + also)
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 177, in make_graph
    package_data = research_package(index_url, package, dependencies[package]['version'])
  File "/usr/local/share/blazar/workspaces/D3615ABB-EC04-4E74-A174-F9AFC7651BE1/infractl/homebrew/.venv/src/homebrew-pypi-poet/poet/poet.py", line 86, in research_package
    distributions = pypi_client.get_project_files(name)
AttributeError: 'PyPISimple' object has no attribute 'get_project_files'
```
This ensures the version of that dependency will be less than v1 to avoid pulling in those breaking changes.