### PR TITLE
Normalize package names

### DIFF
--- a/poet/poet.py
+++ b/poet/poet.py
@@ -20,6 +20,7 @@ import warnings
 
 import pkg_resources
 import pypi_simple
+from packaging.utils import canonicalize_name
 from packaging.version import parse as parse_version, InvalidVersion
 
 from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE, template_from_file
@@ -50,7 +51,7 @@ def recursive_dependencies(package):
     if not isinstance(package, pkg_resources.Requirement):
         raise TypeError("Expected a Requirement; got a %s" % type(package))
 
-    discovered = {package.project_name.lower()}
+    discovered = {canonicalize_name(package.project_name)}
     visited = set()
 
     def walk(package):
@@ -66,7 +67,7 @@ def recursive_dependencies(package):
             reqs = pkg_resources.get_distribution(package).requires(extras)
         except pkg_resources.DistributionNotFound:
             return
-        discovered.update(req.project_name.lower() for req in reqs)
+        discovered.update(canonicalize_name(req.project_name) for req in reqs)
         for req in reqs:
             walk(req)
 
@@ -183,10 +184,10 @@ def make_graph(index_url, pkg):
 
     dependencies = {key: {} for key in pkg_deps if key not in ignore}
     installed_packages = pkg_resources.working_set
-    versions = {package.key: package.version for package in installed_packages}
+    versions = {canonicalize_name(package.key): package.version for package in installed_packages}
     for package in dependencies:
         try:
-            dependencies[package]['version'] = versions[package]
+            dependencies[package]['version'] = versions[canonicalize_name(package)]
         except KeyError:
             warnings.warn("{} is not installed so we cannot compute "
                           "resources for its dependencies.".format(package),
@@ -209,13 +210,12 @@ def formula_for(index_url, package, also=None, template_path=None, include_pytho
     package_name = req.project_name
 
     nodes = merge_graphs(make_graph(index_url, p) for p in [package] + also)
+    normalized_name = canonicalize_name(package_name)
     resources = [value for key, value in nodes.items()
-                 if key.lower() != package_name.lower()]
+                 if canonicalize_name(key) != normalized_name]
 
-    if package_name in nodes:
-        root = nodes[package_name]
-    elif package_name.lower() in nodes:
-        root = nodes[package_name.lower()]
+    if normalized_name in nodes:
+        root = nodes[normalized_name]
     else:
         raise Exception("Could not find package {} in nodes {}".format(package, nodes.keys()))
 
@@ -244,15 +244,16 @@ def merge_graphs(graphs):
     result = {}
     for g in graphs:
         for key in g:
-            if key not in result:
-                result[key] = g[key]
-            elif result[key] == g[key]:
+            normalized = canonicalize_name(key)
+            if normalized not in result:
+                result[normalized] = g[key]
+            elif result[normalized] == g[key]:
                 pass
             else:
                 warnings.warn(
-                    "Merge conflict: {l.name} {l.version} and "
-                    "{r.name} {r.version}; using the former.".
-                    format(l=result[key], r=g[key]),
+                    "Merge conflict: {l[name]} {l[version]} and "
+                    "{r[name]} {r[version]}; using the former.".
+                    format(l=result[normalized], r=g[key]),
                     ConflictingDependencyWarning)
     return OrderedDict([k, result[k]] for k in sorted(result.keys()))
 

--- a/poet/test/test_units.py
+++ b/poet/test/test_units.py
@@ -48,6 +48,16 @@ unlinted = """
 """  # noqa
 
 
+class TestMergeGraphs(object):
+    def test_dotted_and_hyphenated_names_merge(self):
+        g1 = {"jaraco.context": {"name": "jaraco.context", "version": "6.0.1"}}
+        g2 = {"jaraco-context": {"name": "jaraco-context", "version": "6.1.2"}}
+        merged = poet.poet.merge_graphs([g1, g2])
+        assert len(merged) == 1
+        assert "jaraco-context" in merged
+        assert merged["jaraco-context"]["version"] == "6.0.1"
+
+
 class TestLint(object):
     def test_lint(self):
         linted = poet.lint(unlinted)


### PR DESCRIPTION
When using the uv-build or hatchling build backend instead of setuptools and pinning a dependency with a period in it, poet does not respect pins.


What happens is that uv-build/hatchling normalize dependency names: jaraco.context -> jaraco-context in the metadata. Which is then a problem when we run it through poet, because it uses `pkg_resources.working_set` to look up installed packages by name and then cross-references with the metadata's `Requires-Dist` names.

As a result, poet warns `jaraco-context is not installed so we cannot compute resources for its dependencies` because pip installs it as `jaraco.context` (dotted) but poet looks for `jaraco-context` (hyphenated).

So that dep gets added twice, once as dotted and once as hyphenated, and no pins are obeyed. 


```
   resource "jaraco-context" do
     url "https://build.hubteam.com/pypi-safe/mirror/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz"
     sha256 "f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"
   end
   
   resource "jaraco.context" do
     url "https://build.hubteam.com/pypi-safe/mirror/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
     sha256 "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3"
   end
```

This normalizes the name everywhere it's used as a dict key, so that the pins would match what is declared


### Testing
Created a branch of our buildpack that uses this branch, and ensured that something with hatchling now sees:
```
resource "jaraco-classes" do
    url "[https://build.hubteam.com/pypi-safe/mirror/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"](https://build.hubteam.com/pypi-safe/mirror/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz%22)
    sha256 "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"
  end
  resource "jaraco-context" do
    url "[https://build.hubteam.com/pypi-safe/mirror/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"](https://build.hubteam.com/pypi-safe/mirror/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz%22)
    sha256 "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3"
  end
  resource "jaraco-functools" do
    url "[https://build.hubteam.com/pypi-safe/mirror/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"](https://build.hubteam.com/pypi-safe/mirror/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz%22)
    sha256 "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d"
  end
  ```
  
  Also tested that with setuptools, there is no difference, only dashed `jaraco-context` versions appear, as they did prior to this change